### PR TITLE
Exit gracefully if too old to support this plugin

### DIFF
--- a/plugin/indent_guides.vim
+++ b/plugin/indent_guides.vim
@@ -1,6 +1,11 @@
 " Author:   Nate Kane <nathanaelkane AT gmail DOT com>
 " Homepage: http://github.com/nathanaelkane/vim-indent-guides
 
+" Do not load if if vim is too old
+if (v:version == 701 && ! exists('*matchadd')) || (v:version < 701)
+  finish
+endif
+
 if exists('g:loaded_indent_guides') || &cp
   finish
 endif


### PR DESCRIPTION
At work my home directory is mounted on some older machines.
When I use vim on those machines it spams a bunch of errors loading this plugin.
This change addresses that issue.