### PR TITLE
Allow exclude files with no 'filetype' set

### DIFF
--- a/autoload/indent_guides.vim
+++ b/autoload/indent_guides.vim
@@ -277,7 +277,7 @@ endfunction
 " Detect if any of the buffer filetypes should be excluded.
 "
 function! indent_guides#exclude_filetype()
-  for ft in split(&ft, '\.')
+  for ft in split(&ft, '\.', 1)
     if index(g:indent_guides_exclude_filetypes, ft) > -1
       return 1
     end

--- a/doc/indent_guides.txt
+++ b/doc/indent_guides.txt
@@ -172,7 +172,8 @@ Default: 0. Values: 0 or 1.
 
 ------------------------------------------------------------------------------
                                              *'indent_guides_exclude_filetypes'*
-Use this option to specify a list of filetypes to disable the plugin for.
+Use this option to specify a list of filetypes to disable the plugin for. Use
+'' for files with no filetypes set.
 
 Default: ['help']. Values: list of strings.
 >
@@ -265,8 +266,9 @@ Bug reports, feedback, suggestions etc are welcomed.
 7. CHANGELOG                                           *indent-guides-changelog*
 
 1.8 (pending release)~
+  * Allow exclude files with no 'filetype' set (thanks @noscript).
   * Added option g:|indent_guides_soft_pattern| to control the pattern for
-    soft indentation (thanks @sergey-vlasov).
+    soft indentation (thanks @noscript).
   * Added option g:|indent_guides_default_mapping| to control whether the
     default mapping (<Leader>ig) gets set (thanks @suy).
   * Set size of indent guide to `tabstop` value when `shiftwidth=0` or


### PR DESCRIPTION
Rendering indentation in some huge plaintext files can slowdown Vim tremendously. This PR will allow use `''` to specify unset `filetype`, e.g.:
```vim
let g:indent_guides_exclude_filetypes = ['help', 'nerdtree', '']
```

P.S. I renamed myself from `@sergey-vlasov`to `@noscript` :)
