### PR TITLE
Replace :redir with execute() equivalent

### DIFF
--- a/autoload/indent_guides.vim
+++ b/autoload/indent_guides.vim
@@ -246,10 +246,7 @@ endfunction
 " Returns: 'Normal xxx guifg=#323232 guibg=#ffffff'
 "
 function! indent_guides#capture_highlight(group_name)
-  redir => l:output
-  exe "silent hi " . a:group_name
-  redir END
-
+  let l:output = execute("silent hi " . a:group_name)
   let l:output = substitute(l:output, "\n", "", "")
   return l:output
 endfunction


### PR DESCRIPTION
Using lambdas with `execute()` will produce an error if any of the subsequent code uses `:redir`. According to Vim docs (`:h execute()`):
>It is not possible to use `:redir` anywhere in {command}.

In my case I have a mapping that causes indent guides to refresh. This PR replaces use of `:redir` with `execute()` equivalent.

**How to reproduce**
Long version:
```
:IndentGuidesEnable
:edit dummy.vim
:split
:call timer_start(100, { -> execute('wincmd w') })
```

Short version:
```
:edit dummy.vim
:call timer_start(100, { -> execute('IndentGuidesEnable') })
```

Vim output:
```
Error detected while processing function indent_guides#process_autocmds[2]..indent_guides#enable[8]..indent
_guides#init_script_vars[7]..indent_guides#capture_highlight:
line    1:
E930: Cannot use :redir inside execute()
Error detected while processing function indent_guides#process_autocmds[2]..indent_guides#enable[8]..indent
_guides#init_script_vars[7]..indent_guides#capture_highlight:
line    3:
E930: Cannot use :redir inside execute()
Error detected while processing function indent_guides#process_autocmds[2]..indent_guides#enable[8]..indent
_guides#init_script_vars[7]..indent_guides#capture_highlight:
line    5:
E121: Undefined variable: l:output
Error detected while processing function indent_guides#process_autocmds[2]..indent_guides#enable[8]..indent
_guides#init_script_vars[7]..indent_guides#capture_highlight:
line    5:
E116: Invalid arguments for function substitute(l:output, "\n", "", "")
Error detected while processing function indent_guides#process_autocmds[2]..indent_guides#enable[8]..indent
_guides#init_script_vars[7]..indent_guides#capture_highlight:
line    5:
E15: Invalid expression: substitute(l:output, "\n", "", "")
Error detected while processing function indent_guides#process_autocmds[2]..indent_guides#enable[8]..indent
_guides#init_script_vars[7]..indent_guides#capture_highlight:
line    6:
E121: Undefined variable: l:output
Error detected while processing function indent_guides#process_autocmds[2]..indent_guides#enable[8]..indent
_guides#init_script_vars[7]..indent_guides#capture_highlight:
line    6:
E15: Invalid expression: l:output
```
