### PR TITLE
Global variables override by buffer variables (#80)

### DIFF
--- a/autoload/indent_guides.vim
+++ b/autoload/indent_guides.vim
@@ -19,7 +19,7 @@ endfunction
 " other buffers and windows.
 "
 function! indent_guides#process_autocmds()
-  if g:indent_guides_autocmds_enabled
+  if indent_guides#getvar('indent_guides_autocmds_enabled')
     call indent_guides#enable()
   else
     call indent_guides#disable()
@@ -27,11 +27,10 @@ function! indent_guides#process_autocmds()
 endfunction
 
 "
-" Enables the indent guides for the current buffer and any other buffer upon
-" entering it.
+" Enables the indent guides for the current buffer
 "
 function! indent_guides#enable()
-  let g:indent_guides_autocmds_enabled = 1
+  let b:indent_guides_autocmds_enabled = 1
 
   if &diff || indent_guides#exclude_filetype()
     call indent_guides#clear_matches()
@@ -49,11 +48,11 @@ function! indent_guides#enable()
     let l:column_start = (l:level - 1) * s:indent_size + 1
 
     " define the higlight patterns and add to matches list
-    if g:indent_guides_space_guides
-      let l:soft_pattern = indent_guides#indent_highlight_pattern(g:indent_guides_soft_pattern, l:column_start, s:guide_size)
+    if indent_guides#getvar('indent_guides_space_guides')
+      let l:soft_pattern = indent_guides#indent_highlight_pattern(indent_guides#getvar('indent_guides_soft_pattern'), l:column_start, s:guide_size)
       call add(w:indent_guides_matches, matchadd(l:group, l:soft_pattern))
     end
-    if g:indent_guides_tab_guides
+    if indent_guides#getvar('indent_guides_tab_guides')
       let l:hard_pattern = indent_guides#indent_highlight_pattern('\t', l:column_start, s:indent_size)
       call add(w:indent_guides_matches, matchadd(l:group, l:hard_pattern))
     end
@@ -65,7 +64,7 @@ endfunction
 " entering it.
 "
 function! indent_guides#disable()
-  let g:indent_guides_autocmds_enabled = 0
+  let b:indent_guides_autocmds_enabled = 0
   call indent_guides#clear_matches()
 endfunction
 
@@ -194,19 +193,19 @@ function! indent_guides#init_script_vars()
   let s:hi_normal = substitute(s:hi_normal, ' font=[A-Za-z0-9:]\+', "", "")
 
   " shortcuts to the global variables - this makes the code easier to read
-  let s:debug             = g:indent_guides_debug
-  let s:indent_levels     = g:indent_guides_indent_levels
-  let s:auto_colors       = g:indent_guides_auto_colors
-  let s:color_hex_pat     = g:indent_guides_color_hex_pattern
-  let s:color_hex_bg_pat  = g:indent_guides_color_hex_guibg_pattern
-  let s:color_name_bg_pat = g:indent_guides_color_name_guibg_pattern
-  let s:start_level       = g:indent_guides_start_level
+  let s:debug             = indent_guides#getvar('indent_guides_debug')
+  let s:indent_levels     = indent_guides#getvar('indent_guides_indent_levels')
+  let s:auto_colors       = indent_guides#getvar('indent_guides_auto_colors')
+  let s:color_hex_pat     = indent_guides#getvar('indent_guides_color_hex_pattern')
+  let s:color_hex_bg_pat  = indent_guides#getvar('indent_guides_color_hex_guibg_pattern')
+  let s:color_name_bg_pat = indent_guides#getvar('indent_guides_color_name_guibg_pattern')
+  let s:start_level       = indent_guides#getvar('indent_guides_start_level')
 
   " str2float not available in vim versions <= 7.1
   if has('float')
-    let s:change_percent = g:indent_guides_color_change_percent / str2float('100.0')
+    let s:change_percent = indent_guides#getvar('indent_guides_color_change_percent') / str2float('100.0')
   else
-    let s:change_percent = g:indent_guides_color_change_percent / 100.0
+    let s:change_percent = indent_guides#getvar('indent_guides_color_change_percent') / 100.0
   endif
 
   if s:debug
@@ -230,7 +229,7 @@ endfunction
 " NOTE: Currently, this only works when soft-tabs are being used.
 "
 function! indent_guides#calculate_guide_size()
-  let l:guide_size = g:indent_guides_guide_size
+  let l:guide_size = indent_guides#getvar('indent_guides_guide_size')
 
   if l:guide_size == 0 || l:guide_size > s:indent_size
     let l:guide_size = s:indent_size
@@ -278,9 +277,26 @@ endfunction
 "
 function! indent_guides#exclude_filetype()
   for ft in split(&ft, '\.')
-    if index(g:indent_guides_exclude_filetypes, ft) > -1
+    if index(indent_guides#getvar('indent_guides_exclude_filetypes'), ft) > -1
       return 1
     end
   endfor
   return 0
+endfunction
+
+"
+" Return variables value
+" Choose local buffer variable first if exist or global variable if not
+" return -1 if none of local buffer / global variable exists
+"
+function! indent_guides#getvar(var)
+  let varName=a:var
+  if (exists ("b:" . varName))
+    exe "let retVal=b:" . varName
+  elseif (exists ("g:" . varName))
+    exe "let retVal=g:" . varName
+  else
+    exe "let retVal=-1"
+  endif
+  return retVal
 endfunction

--- a/doc/indent_guides.txt
+++ b/doc/indent_guides.txt
@@ -63,6 +63,14 @@ Features:~
 ==============================================================================
 3. OPTIONS                                               *indent-guides-options*
 
+All options described bellow could be used at buffer level if needed without
+cluttering the other windows / buffers. The buffer variables could be used for
+example to change only settings for particular filetype with ftplugin files.
+
+Example (in ~/vim/ftplugin/sh.vim):
+>
+  let b:indent_guides_indent_levels = 50
+<
 ------------------------------------------------------------------------------
                                                  *'indent_guides_indent_levels'*
 Use this option to control how many indent levels to display guides for.
@@ -163,7 +171,8 @@ Default: '\s'. Values: Vim regexp.
 
 ------------------------------------------------------------------------------
                                          *'indent_guides_enable_on_vim_startup'*
-Use this option to control whether the plugin is enabled on Vim startup.
+Use this option to control whether the plugin is enabled on Vim startup and
+future buffers.
 
 Default: 0. Values: 0 or 1.
 >

--- a/plugin/indent_guides.vim
+++ b/plugin/indent_guides.vim
@@ -82,6 +82,7 @@ augroup indent_guides
   autocmd!
 
   if g:indent_guides_enable_on_vim_startup
+    let g:indent_guides_autocmds_enabled = 1
     autocmd VimEnter * :IndentGuidesEnable
   endif
 


### PR DESCRIPTION
Hi,

Not a vim expert but seems to do the job requested by #80 and had personally the same needs.

It should allow users to be able to :

- enable/disable indent-guides at the buffer level
- tweak indent-guides at filetype / buffer level

For example, if you want :
- only tab indentation inside sh files
- only enable/show indent-guides for sh files
```
$ cat vimrc
let g:indent_guides_enable_on_vim_startup = 0
let g:indent_guides_tab_guides = 0
let g:indent_guides_space_guides = 1
let g:indent_guides_soft_pattern = ' '
```
```
$ cat after/ftplugin/sh.vim 
setlocal noexpandtab
setlocal softtabstop=0
setlocal shiftwidth=4
setlocal tabstop=4

autocmd BufEnter * IndentGuidesEnable
let b:indent_guides_tab_guides = 1  
let b:indent_guides_space_guides = 0
let b:indent_guides_soft_pattern = '\t'
```
If you want enable indent-guides for all filetype / buffers except for sh filetype

```
$ cat vimrc
let g:indent_guides_enable_on_vim_startup = 1
```
```
$ cat after/ftplugin/sh.vim 
autocmd BufEnter * IndentGuidesDisable
```

Comments / suggestions welcome