### PR TITLE
Make sure to clear IndentGuides matches completely

### DIFF
--- a/autoload/indent_guides.vim
+++ b/autoload/indent_guides.vim
@@ -86,6 +86,13 @@ function! indent_guides#clear_matches()
       let l:index += l:index
     endfor
   endif
+
+  " Make sure to clear indent guide if remembered match id has gone somehow.
+  for l:match in getmatches()
+    if l:match.group =~# '^IndentGuides\v(Even|Odd)$'
+      call matchdelete(l:match.id)
+    endif
+  endfor
 endfunction
 
 "


### PR DESCRIPTION
Sometimes it left IndentGuides matches even if `:IndentGuidesDisable` is called.

Now it deletes the stored match id only.
So, if accidentally they has gone, the matches sticks uncleared
(Updated the buffer by some other plugin?).

Shouldn't you clear them completely by deleting matches of `IndentGuides{Even,Odd}` groups?
